### PR TITLE
環境変数展開の修正、その他

### DIFF
--- a/srcs/execute/cd_execute.c
+++ b/srcs/execute/cd_execute.c
@@ -33,7 +33,7 @@ void	execute_cd(t_cmd_args *args)
 		if (chdir(args->cmdpath[1]) != 0)
 		{
 			perror(args->cmdpath[1]);
-			g_minishell.exit_status = 2;
+			g_minishell.exit_status = 1;
 		}
 		else
 			g_minishell.exit_status = 0;

--- a/srcs/execute/cd_execute.c
+++ b/srcs/execute/cd_execute.c
@@ -25,7 +25,7 @@ void	execute_cd(t_cmd_args *args)
 {
 	if (args->cmdpath_argc == 1)
 	{
-		chdir(getenv("HOME"));
+		chdir(get_env_value("HOME"));
 		g_minishell.exit_status = 0;
 	}
 	else

--- a/srcs/execute/dupfor_redirection.c
+++ b/srcs/execute/dupfor_redirection.c
@@ -13,6 +13,7 @@
 #include "../includes/execute.h"
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <fcntl.h>
 
 // TODO: heredocへの対応

--- a/srcs/execute/expansion_utils.c
+++ b/srcs/execute/expansion_utils.c
@@ -30,7 +30,7 @@ char	*expand_united_enval(char *str)
 		return (res);
 	}
 	split = split_non_alnum(str);
-	enval = getenv(split[0]);
+	enval = get_env_value(split[0]);
 	if (enval)
 		res = ft_strjoin(enval, split[1]);
 	else

--- a/srcs/execute/expansion_utils2.c
+++ b/srcs/execute/expansion_utils2.c
@@ -44,7 +44,7 @@ char	*first_enval(char *str, char *split)
 				res = ft_itoa(g_minishell.exit_status);
 			else
 			{
-				res = getenv(split);
+				res = get_env_value(split);
 				if (res)
 					res = ft_strdup(res);
 			}


### PR DESCRIPTION
- 環境変数を展開する箇所の`getenv()`を`get_env_value()`に置き換えました
- srcs/execute/dupfor_redirection.c に`sys/wait.h`を追加しました
- execute_cdのexit_statusを変更しました（すみませんでした）